### PR TITLE
add "_.id" instead of ".id"

### DIFF
--- a/models/note.js
+++ b/models/note.js
@@ -19,7 +19,7 @@ const noteSchema = new mongoose.Schema({
 
 noteSchema.set('toJSON', {
   transform: (document, returnedObject) => {
-    returnedObject.id = returnedObject._id.toString()
+    returnedObject_.id = returnedObject._id.toString()
     delete returnedObject._id
     delete returnedObject.__v
   }


### PR DESCRIPTION
On noteSchema, the returnedObject.id is assigned as "returnedObject._id.toString()", but it should be assigned to "returnedObject._id" instead to remove id